### PR TITLE
Adds the ability for other plugins to update the dataset on the fly

### DIFF
--- a/js/chartjsModel.js
+++ b/js/chartjsModel.js
@@ -3,10 +3,29 @@ define([
 ], function(ComponentModel){
 
   var ChartJSModel = ComponentModel.extend({
-    
+    /**
+     * Updates an existing dataset for a chart.
+     *
+     * @param  {array} datasetData  An array of the new data points.
+     * @param  {int} datasetIndex The index of the dataset to update (defaults to 0.)
+     */
+    updateDataset: function(datasetData, datasetIndex) {
+      datasetIndex = datasetIndex || 0;
 
+      var data = this.get("data");
+      if (!data) {
+        throw new Error("This chart instance has no data; it may be improperly configured");
+      }
 
+      if (!data.datasets || datasetIndex >= data.datasets.length) {
+        throw new RangeError("Cannot update a nonexistent dataset");
+      }
 
+      data.datasets[datasetIndex].data = datasetData;
+
+      this.trigger("change:data");
+    }
   });
 
+  return ChartJSModel;
 });

--- a/js/chartjsView.js
+++ b/js/chartjsView.js
@@ -14,6 +14,7 @@ define([
             this.listenTo(Adapt, 'device:resize', this.onScreenSizeChanged);
             this.listenTo(Adapt, 'device:changed', this.onDeviceChanged);
             this.listenTo(Adapt, 'accessibility:toggle', this.onAccessibilityToggle);
+            this.listenTo(this.model, 'change:data', this.onDataChanged);
             this.checkIfResetOnRevisit();
         },
 
@@ -24,7 +25,7 @@ define([
 
         setupChart: function() {
             var ctx = $("#myChart"+this.model.get('_id'));
-            var myChart = new Chart(ctx, {
+            var chart = new Chart(ctx, {
                 type: this.model.get('_chartType'),
                 data: this.model.get('data'),
                 options: this.model.get('_options')
@@ -32,6 +33,15 @@ define([
 
             this.setReadyStatus();
 
+            this.model.set("_chart", chart);
+        },
+
+        onDataChanged: function() {
+            var chart = this.model.get("_chart");
+
+            if (chart) {
+                chart.update();
+            }
         },
 
         setupEventListeners: function() {


### PR DESCRIPTION
We have a course where the chart's data changes based on user input. This adds a convenience method to the model to update the data in a specified dataset. This updates the model and triggers an update call on the chart so it animates the change.